### PR TITLE
refactor: clean up use of newer APIs

### DIFF
--- a/lua/cmp/config/compare.lua
+++ b/lua/cmp/config/compare.lua
@@ -52,7 +52,7 @@ end
 compare.recently_used = setmetatable({
   records = {},
   add_entry = function(self, e)
-    self.records[e.completion_item.label] = vim.uv.now() or vim.loop.now()
+    self.records[e.completion_item.label] = (vim.uv or vim.loop).now()
   end,
 }, {
   ---@type fun(self: table, entry1: cmp.Entry, entry2: cmp.Entry): boolean|nil

--- a/lua/cmp/context.lua
+++ b/lua/cmp/context.lua
@@ -44,7 +44,7 @@ context.new = function(prev_context, option)
   self.prev_context = prev_context or context.empty()
   self.option = option or { reason = types.cmp.ContextReason.None }
   self.filetype = vim.api.nvim_get_option_value('filetype', { buf = 0 })
-  self.time = vim.uv.now() or vim.loop.now()
+  self.time = (vim.uv or vim.loop).now()
   self.bufnr = vim.api.nvim_get_current_buf()
 
   local cursor = api.get_cursor()

--- a/lua/cmp/source.lua
+++ b/lua/cmp/source.lua
@@ -79,7 +79,7 @@ end
 ---Get fetching time
 source.get_fetching_time = function(self)
   if self.status == source.SourceStatus.FETCHING then
-    return vim.uv.now() - self.context.time or vim.loop.now() - self.context.time
+    return (vim.uv or vim.loop).now() - self.context.time
   end
   return 100 * 1000 -- return pseudo time if source isn't fetching.
 end

--- a/lua/cmp/utils/async.lua
+++ b/lua/cmp/utils/async.lua
@@ -1,5 +1,6 @@
 local feedkeys = require('cmp.utils.feedkeys')
 local config = require('cmp.config')
+local uv = vim.uv or vim.loop
 
 local async = {}
 
@@ -61,11 +62,11 @@ async.throttle = function(fn, timeout)
       local args = { ... }
 
       if time == nil then
-        time = vim.uv.now() or vim.loop.now()
+        time = uv.now()
       end
       self.stop(false)
       self.running = true
-      timer:start(math.max(1, self.timeout - (vim.uv.now() - time or vim.loop.now() - time)), 0, function()
+      timer:start(math.max(1, self.timeout - (uv.now() - time)), 0, function()
         vim.schedule(function()
           time = nil
           local ret = fn(unpack(args))
@@ -116,7 +117,7 @@ async.timeout = function(fn, timeout)
       fn(...)
     end
   end
-  timer = vim.uv.new_timer() or vim.loop.new_timer()
+  timer = uv.new_timer()
   timer:start(timeout, 0, function()
     callback()
   end)
@@ -176,7 +177,7 @@ end
 
 local Scheduler = {}
 Scheduler._queue = {}
-Scheduler._executor = assert(vim.uv.new_check() or vim.loop.new_check())
+Scheduler._executor = assert(uv.new_check())
 
 function Scheduler.step()
   local budget = config.get().performance.async_budget * 1e6

--- a/lua/cmp/utils/async_spec.lua
+++ b/lua/cmp/utils/async_spec.lua
@@ -1,4 +1,5 @@
 local async = require('cmp.utils.async')
+local uv = vim.uv or vim.loop
 
 describe('utils.async', function()
   it('throttle', function()
@@ -9,22 +10,22 @@ describe('utils.async', function()
     end, 100)
 
     -- 1. delay for 100ms
-    now = vim.uv.now() or vim.loop.now()
+    now = uv.now()
     f.timeout = 100
     f()
     vim.wait(1000, function()
       return count == 1
     end)
-    assert.is.truthy(math.abs(f.timeout - (vim.uv.now() - now or vim.loop.now() - now)) < 10)
+    assert.is.truthy(math.abs(f.timeout - (uv.now() - now)) < 10)
 
     -- 2. delay for 500ms
-    now = vim.uv.now() or vim.loop.now()
+    now = uv.now()
     f.timeout = 500
     f()
     vim.wait(1000, function()
       return count == 2
     end)
-    assert.is.truthy(math.abs(f.timeout - (vim.uv.now() - now or vim.loop.now() - now)) < 10)
+    assert.is.truthy(math.abs(f.timeout - (uv.now() - now)) < 10)
 
     -- 4. delay for 500ms and wait 100ms (remain 400ms)
     f.timeout = 500
@@ -32,13 +33,13 @@ describe('utils.async', function()
     vim.wait(100) -- remain 400ms
 
     -- 5. call immediately (100ms already elapsed from No.4)
-    now = vim.uv.now() or vim.loop.now()
+    now = uv.now()
     f.timeout = 100
     f()
     vim.wait(1000, function()
       return count == 3
     end)
-    assert.is.truthy(math.abs(vim.uv.now() - now or vim.loop.now() - now) < 10)
+    assert.is.truthy(math.abs(uv.now() - now) < 10)
   end)
   it('step', function()
     local done = false


### PR DESCRIPTION
This cleans up the use of `vim.uv` vs `vim.loop`. It also improves the performance marginally by decreasing the number of comparators